### PR TITLE
Simple patch to remove lxml dependency for parsing LinkedIn data

### DIFF
--- a/simpleauth/handler.py
+++ b/simpleauth/handler.py
@@ -451,9 +451,7 @@ class SimpleAuthHandler(object):
       # libraries need this for providers like LinkedIn
       from lxml import etree
     except ImportError:
-      logging.error('requirement `lxml.etree` was not provided. please '
-                    'make sure you have enabled it in app.yaml')
-      raise
+      import xml.etree.ElementTree as etree
     person = etree.fromstring(content)
     uinfo = {}
     for e in person:


### PR DESCRIPTION
Python has its own, potentially slower, ElementTree implementation. Fall back on that to parse the quite short LinkedIn xml rather than raising an exception if lxml is not present. Those who want the speed increase can include lxml in their libs and still benefit.
