### PR TITLE
change facebook token response parser to use json

### DIFF
--- a/simpleauth/handler.py
+++ b/simpleauth/handler.py
@@ -118,7 +118,7 @@ class SimpleAuthHandler(object):
     'googleplus': '_json_parser',
     'windows_live': '_json_parser',
     'foursquare': '_json_parser',
-    'facebook': '_query_string_parser',
+    'facebook': '_json_parser',
     'linkedin': '_query_string_parser',
     'linkedin2': '_json_parser',
     'twitter': '_query_string_parser'


### PR DESCRIPTION
There was a breaking change in the facebook api from 2.2 -> 2.3. Support for 2.2 was dropped on the 27th March 2017.

From https://developers.facebook.com/docs/apps/changelog:

[Oauth Access Token] Format - The response format of https://www.facebook.com/v2.3/oauth/access_token returned when you exchange a code for an access_token now return valid JSON instead of being URL encoded. The new format of this response is {"access_token": {TOKEN}, "token_type":{TYPE}, "expires_in":{TIME}}. We made this update to be compliant with section 5.1 of RFC 6749.